### PR TITLE
fix: add go mod tidy to renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -16,5 +16,8 @@
   "rebaseWhen": "conflicted",
   "labels": [
     "dependencies"
+  ],
+  "postUpdateOptions": [
+    "gomodTidy"
   ]
 }


### PR DESCRIPTION
## Summary

Add `go mod tidy` to Renovate's update.

fixes #15 