### PR TITLE
refactor: move client to another package

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -1,4 +1,4 @@
-package collector
+package client
 
 import (
 	"encoding/json"
@@ -36,7 +36,7 @@ func NewPalworldClient(config *config.Config) *PalworldClient {
 	}
 }
 
-func (c *PalworldClient) getPalworldMetrics() (*PalworldMetricsResponse, error) {
+func (c *PalworldClient) GetMetrics() (*PalworldMetricsResponse, error) {
 	client := http.Client{Timeout: time.Duration(defaultTimeout)}
 	req, err := http.NewRequest(http.MethodGet, c.scrapeURI, nil)
 	if err != nil {

--- a/collector/exporter.go
+++ b/collector/exporter.go
@@ -4,6 +4,7 @@ import (
 	"log/slog"
 	"sync"
 
+	"github.com/jimmysharp/palworld_exporter/client"
 	"github.com/jimmysharp/palworld_exporter/config"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -16,7 +17,7 @@ type Exporter struct {
 	mutex sync.Mutex
 
 	logger *slog.Logger
-	client *PalworldClient
+	client *client.PalworldClient
 
 	up               *prometheus.Desc
 	serverFps        *prometheus.Desc
@@ -29,7 +30,7 @@ type Exporter struct {
 func NewExporter(config *config.Config, logger *slog.Logger) *Exporter {
 	return &Exporter{
 		logger: logger,
-		client: NewPalworldClient(config),
+		client: client.NewPalworldClient(config),
 		up: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, "", "up"),
 			"Palworld server up",
@@ -76,7 +77,7 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 	e.mutex.Lock()
 	defer e.mutex.Unlock()
 
-	metrics, err := e.client.getPalworldMetrics()
+	metrics, err := e.client.GetMetrics()
 
 	if err != nil {
 		e.logger.Error("Error getting metrics", slog.String("err", err.Error()))


### PR DESCRIPTION
### Summary

Move `PalworldClient` to another package `client`.

close #22 